### PR TITLE
feat(client): render tracked mobs through walls with textured xray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Semantic Versioning: https://semver.org/spec/v2.0.0.html
 
 
+## [1.4.0] - 2026-07-06
+### Added
+- Add model-based x-ray rendering for tracked mobs (courtesy of @zzhalex233), with a config toggle to switch between this new textured rendering and the old vanilla outline glow.
+
+
 ## [1.3.0] - 2026-06-15
 ### Added
 - Add JSON-based external spawn hints for mobs that do not use normal biome spawn tables, with documented example and JSON Schema.

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.2.5"
+version = "1.4.0"
 group = "com.supermobtracker"
 archivesBaseName = "supermobtracker"
 

--- a/src/main/java/com/supermobtracker/client/ClientProxy.java
+++ b/src/main/java/com/supermobtracker/client/ClientProxy.java
@@ -11,6 +11,7 @@ import com.supermobtracker.config.ModConfig;
 import com.supermobtracker.client.event.ClientEvents;
 import com.supermobtracker.client.gui.GuiHandler;
 import com.supermobtracker.client.input.KeyBindings;
+import com.supermobtracker.client.render.TrackedEntityXrayRenderer;
 import com.supermobtracker.tracking.SpawnEventHandler;
 import com.supermobtracker.tracking.SpawnTrackerManager;
 
@@ -25,6 +26,7 @@ public class ClientProxy implements IProxy {
     @Override
     public void init() {
         MinecraftForge.EVENT_BUS.register(new ClientEvents());
+        MinecraftForge.EVENT_BUS.register(new TrackedEntityXrayRenderer());
 
         // Register spawn event handler if tracking is enabled
         if (ModConfig.clientEnableTracking) MinecraftForge.EVENT_BUS.register(new SpawnEventHandler());

--- a/src/main/java/com/supermobtracker/client/event/ClientEvents.java
+++ b/src/main/java/com/supermobtracker/client/event/ClientEvents.java
@@ -1,5 +1,13 @@
 package com.supermobtracker.client.event;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiButton;
@@ -29,19 +37,12 @@ import com.supermobtracker.config.ModConfig;
 import com.supermobtracker.config.ModConfig.HudPosition;
 import com.supermobtracker.tracking.SpawnTrackerManager;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 
 public class ClientEvents {
 
     private static final int BUTTON_ID = 9001;
     private static final int BUTTON_SIZE = 8;
+    private static final String TEMP_GLOW_TAG = "smt_temp_glow";
 
     // Cached inventory tracker button bounds for tooltip rendering
     private static int trackerX = -1;
@@ -52,6 +53,9 @@ public class ClientEvents {
     // Reflection fields for accessing guiLeft/guiTop
     private static Field guiLeftField;
     private static Field guiTopField;
+
+    // Whether we already cleared the temporary glow for switching to model xray mode, to avoid re-clearing every tick
+    private boolean clearedOutlineGlowForXray = false;
 
     static {
         try {
@@ -87,14 +91,51 @@ public class ClientEvents {
         if (event.phase != TickEvent.Phase.END) return;
 
         Minecraft mc = Minecraft.getMinecraft();
-        if (mc.world == null) return;
+        if (mc.world == null || mc.player == null) return;
+
+        // If we just switched to model xray mode, clear any existing temporary glow from the outline mode
+        if (ModConfig.isClientUseModelXRay()) {
+            if (!clearedOutlineGlowForXray) {
+                clearTemporaryGlow(mc.world.loadedEntityList);
+                clearedOutlineGlowForXray = true;
+            }
+
+            return;
+        }
+
+        clearedOutlineGlowForXray = false;
 
         for (Entity entity : mc.world.loadedEntityList) {
-            if (entity.getEntityData().getBoolean("smt_temp_glow")) {
-                entity.setGlowing(false);
-                entity.getEntityData().removeTag("smt_temp_glow");
+            boolean withinRange = mc.player.getDistanceSq(entity) <= ModConfig.clientDetectionRange * ModConfig.clientDetectionRange;
+            boolean tracked = SpawnTrackerManager.isTracked(entity);
+            boolean allowed = false;
+
+            if (tracked && withinRange) {
+                ResourceLocation entId = EntityList.getKey(entity);
+                allowed = entId != null && ModConfig.isEntityAllowed(entId.toString());
+            }
+
+            if (tracked && withinRange && allowed) {
+                if (!entity.isGlowing()) {
+                    entity.setGlowing(true);
+                    entity.getEntityData().setBoolean(TEMP_GLOW_TAG, true);
+                }
+            } else {
+                clearTemporaryGlow(entity);
             }
         }
+    }
+
+    // The outline mode owns this temporary glow state, so switching to model xray must clear it immediately.
+    private void clearTemporaryGlow(List<Entity> entities) {
+        for (Entity entity : entities) clearTemporaryGlow(entity);
+    }
+
+    private void clearTemporaryGlow(Entity entity) {
+        if (!entity.getEntityData().getBoolean(TEMP_GLOW_TAG)) return;
+
+        entity.setGlowing(false);
+        entity.getEntityData().removeTag(TEMP_GLOW_TAG);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/supermobtracker/client/event/ClientEvents.java
+++ b/src/main/java/com/supermobtracker/client/event/ClientEvents.java
@@ -87,28 +87,12 @@ public class ClientEvents {
         if (event.phase != TickEvent.Phase.END) return;
 
         Minecraft mc = Minecraft.getMinecraft();
-        if (mc.world == null || mc.player == null) return;
+        if (mc.world == null) return;
 
         for (Entity entity : mc.world.loadedEntityList) {
-            boolean withinRange = mc.player.getDistanceSq(entity) <= ModConfig.clientDetectionRange * ModConfig.clientDetectionRange;
-            boolean tracked = SpawnTrackerManager.isTracked(entity);
-            boolean allowed = false;
-
-            if (tracked && withinRange) {
-                ResourceLocation entId = EntityList.getKey(entity);
-                allowed = entId != null && ModConfig.isEntityAllowed(entId.toString());
-            }
-
-            if (tracked && withinRange && allowed) {
-                if (!entity.isGlowing()) {
-                    entity.setGlowing(true);
-                    entity.getEntityData().setBoolean("smt_temp_glow", true);
-                }
-            } else {
-                if (entity.getEntityData().getBoolean("smt_temp_glow")) {
-                    entity.setGlowing(false);
-                    entity.getEntityData().removeTag("smt_temp_glow");
-                }
+            if (entity.getEntityData().getBoolean("smt_temp_glow")) {
+                entity.setGlowing(false);
+                entity.getEntityData().removeTag("smt_temp_glow");
             }
         }
     }

--- a/src/main/java/com/supermobtracker/client/render/TrackedEntityXrayRenderer.java
+++ b/src/main/java/com/supermobtracker/client/render/TrackedEntityXrayRenderer.java
@@ -51,6 +51,7 @@ public class TrackedEntityXrayRenderer {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRenderWorldLast(RenderWorldLastEvent event) {
         if (renderingXrayPass) return;
+        if (!ModConfig.isClientUseModelXRay()) return;
 
         Minecraft mc = Minecraft.getMinecraft();
         Entity viewer = mc.getRenderViewEntity();

--- a/src/main/java/com/supermobtracker/client/render/TrackedEntityXrayRenderer.java
+++ b/src/main/java/com/supermobtracker/client/render/TrackedEntityXrayRenderer.java
@@ -1,0 +1,294 @@
+package com.supermobtracker.client.render;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.lwjgl.opengl.GL11;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.client.renderer.entity.RenderLivingBase;
+import net.minecraft.client.shader.Framebuffer;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.MinecraftForgeClient;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import com.supermobtracker.SuperMobTracker;
+import com.supermobtracker.config.ModConfig;
+import com.supermobtracker.tracking.SpawnTrackerManager;
+
+
+/**
+ * Draws tracked entities through world geometry with their normal texture.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+@SideOnly(Side.CLIENT)
+public class TrackedEntityXrayRenderer {
+    private static final int PASS_STENCIL = 0;
+    private static final int PASS_DEPTH = 1;
+    private static final int PASS_COLOR = 2;
+
+    private static Field shadowSizeField;
+    private static boolean shadowFieldInitialized;
+
+    private final Set<String> renderErrorIds = new HashSet<>();
+    private int stencilMask = -1;
+    private boolean renderingXrayPass;
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onRenderWorldLast(RenderWorldLastEvent event) {
+        if (renderingXrayPass) return;
+
+        Minecraft mc = Minecraft.getMinecraft();
+        Entity viewer = mc.getRenderViewEntity();
+        if (mc.world == null || mc.player == null || viewer == null) return;
+        if (SpawnTrackerManager.getTrackedIds().isEmpty()) return;
+
+        float partialTicks = event.getPartialTicks();
+        double viewerX = interpolate(viewer.lastTickPosX, viewer.posX, partialTicks);
+        double viewerY = interpolate(viewer.lastTickPosY, viewer.posY, partialTicks);
+        double viewerZ = interpolate(viewer.lastTickPosZ, viewer.posZ, partialTicks);
+        List<XrayRenderEntry> entries = collectRenderEntries(mc, viewer, partialTicks, viewerX, viewerY, viewerZ);
+        if (entries.isEmpty() || !ensureStencilBuffer(mc)) return;
+
+        float lastBrightnessX = OpenGlHelper.lastBrightnessX;
+        float lastBrightnessY = OpenGlHelper.lastBrightnessY;
+        renderingXrayPass = true;
+        try {
+            renderXray(entries);
+        } finally {
+            restoreXrayState(lastBrightnessX, lastBrightnessY);
+            renderingXrayPass = false;
+        }
+    }
+
+    private List<XrayRenderEntry> collectRenderEntries(Minecraft mc, Entity viewer, float partialTicks,
+                                                       double viewerX, double viewerY, double viewerZ) {
+        List<XrayRenderEntry> entries = new ArrayList<>();
+
+        for (Entity entity : mc.world.loadedEntityList) {
+            if (!(entity instanceof EntityLivingBase)) continue;
+
+            EntityLivingBase living = (EntityLivingBase) entity;
+            ResourceLocation entityId = getRenderableTrackedEntityId(mc, viewer, living);
+            if (entityId == null) continue;
+
+            Render renderer = mc.getRenderManager().getEntityRenderObject(living);
+            if (!(renderer instanceof RenderLivingBase)) continue;
+
+            double x = interpolate(living.lastTickPosX, living.posX, partialTicks) - viewerX;
+            double y = interpolate(living.lastTickPosY, living.posY, partialTicks) - viewerY;
+            double z = interpolate(living.lastTickPosZ, living.posZ, partialTicks) - viewerZ;
+            entries.add(new XrayRenderEntry(entityId, living, (RenderLivingBase) renderer, x, y, z, living.rotationYaw, partialTicks));
+        }
+
+        return entries;
+    }
+
+    private ResourceLocation getRenderableTrackedEntityId(Minecraft mc, Entity viewer, Entity entity) {
+        if (entity == viewer || entity.isDead) return null;
+        if (!SpawnTrackerManager.isTracked(entity)) return null;
+
+        double range = ModConfig.clientDetectionRange;
+        if (mc.player.getDistanceSq(entity) > range * range) return null;
+
+        ResourceLocation entityId = EntityList.getKey(entity);
+        if (entityId == null) return null;
+
+        String idString = entityId.toString();
+        if (!ModConfig.isEntityAllowed(idString)) return null;
+        if (ModConfig.shouldRenderEntity(idString)) return null;
+        if (renderErrorIds.contains(idString)) return null;
+
+        return entityId;
+    }
+
+    private void renderXray(List<XrayRenderEntry> entries) {
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilMask(stencilMask);
+        GL11.glClearStencil(0);
+        GlStateManager.clear(GL11.GL_STENCIL_BUFFER_BIT);
+
+        try {
+            renderPass(entries, PASS_STENCIL);
+
+            GlStateManager.clearDepth(1.0D);
+            GlStateManager.clear(GL11.GL_DEPTH_BUFFER_BIT);
+            renderPass(entries, PASS_DEPTH);
+
+            renderPass(entries, PASS_COLOR);
+        } finally {
+            GlStateManager.colorMask(true, true, true, true);
+            GL11.glStencilMask(0xFF);
+            GL11.glDisable(GL11.GL_STENCIL_TEST);
+        }
+    }
+
+    private void renderPass(List<XrayRenderEntry> entries, int pass) {
+        for (XrayRenderEntry entry : entries) {
+            if (renderErrorIds.contains(entry.entityId.toString())) continue;
+
+            preparePass(pass);
+            try {
+                renderEntry(entry);
+            } catch (Throwable t) {
+                String idString = entry.entityId.toString();
+                if (renderErrorIds.add(idString)) {
+                    SuperMobTracker.LOGGER.warn("Disabled xray rendering for {} after render failure: {}", idString, t.getMessage());
+                }
+            }
+        }
+    }
+
+    private void preparePass(int pass) {
+        if (pass == PASS_STENCIL) {
+            GL11.glStencilMask(stencilMask);
+            GL11.glStencilFunc(GL11.GL_ALWAYS, stencilMask, stencilMask);
+            GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
+            prepareXrayState(false, false, GL11.GL_GREATER);
+            return;
+        }
+
+        GL11.glStencilMask(0x00);
+        GL11.glStencilFunc(GL11.GL_EQUAL, stencilMask, stencilMask);
+        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_KEEP);
+        prepareXrayState(pass == PASS_COLOR, pass == PASS_DEPTH, pass == PASS_DEPTH ? GL11.GL_LEQUAL : GL11.GL_EQUAL);
+    }
+
+    private static void renderEntry(XrayRenderEntry entry) throws IllegalAccessException {
+        Float originalShadowSize = suppressShadow(entry.renderer);
+        try {
+            entry.renderer.doRender(entry.entity, entry.x, entry.y, entry.z, entry.yaw, entry.partialTicks);
+        } finally {
+            restoreShadow(entry.renderer, originalShadowSize);
+        }
+    }
+
+    private boolean ensureStencilBuffer(Minecraft minecraft) {
+        Framebuffer framebuffer = minecraft.getFramebuffer();
+        if (framebuffer == null || !framebuffer.isStencilEnabled() && !framebuffer.enableStencil()) {
+            return false;
+        }
+
+        if (stencilMask < 0) {
+            int stencilBit = MinecraftForgeClient.reserveStencilBit();
+            if (stencilBit < 0) return false;
+            stencilMask = 1 << stencilBit;
+        }
+
+        return true;
+    }
+
+    private static void prepareXrayState(boolean writeColor, boolean writeDepth, int depthFunc) {
+        OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
+        GlStateManager.enableTexture2D();
+        GlStateManager.enableDepth();
+        GlStateManager.depthFunc(depthFunc);
+        GlStateManager.depthMask(writeDepth);
+        GlStateManager.colorMask(writeColor, writeColor, writeColor, writeColor);
+        GlStateManager.disableLighting();
+        RenderHelper.disableStandardItemLighting();
+        GlStateManager.enableAlpha();
+        GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
+        GlStateManager.disableBlend();
+        GlStateManager.enableCull();
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
+        OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
+    }
+
+    private static void restoreXrayState(float lastBrightnessX, float lastBrightnessY) {
+        OpenGlHelper.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX, lastBrightnessY);
+        OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
+
+        GlStateManager.colorMask(true, true, true, true);
+        GlStateManager.depthMask(true);
+        GlStateManager.depthFunc(GL11.GL_LEQUAL);
+        GlStateManager.disableBlend();
+        GlStateManager.enableAlpha();
+        GlStateManager.enableDepth();
+        GlStateManager.enableCull();
+        GlStateManager.enableTexture2D();
+        GlStateManager.enableLighting();
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+    }
+
+    private static Float suppressShadow(RenderLivingBase renderer) throws IllegalAccessException {
+        if (!shadowFieldInitialized) initShadowField();
+        if (shadowSizeField == null) return null;
+
+        float original = shadowSizeField.getFloat(renderer);
+        shadowSizeField.setFloat(renderer, 0.0F);
+        return original;
+    }
+
+    private static void restoreShadow(RenderLivingBase renderer, Float originalShadowSize) {
+        if (shadowSizeField == null || originalShadowSize == null) return;
+
+        try {
+            shadowSizeField.setFloat(renderer, originalShadowSize);
+        } catch (IllegalAccessException ignored) {
+            // Rendering can continue; the field is restored on the next renderer instance.
+        }
+    }
+
+    private static void initShadowField() {
+        shadowFieldInitialized = true;
+
+        try {
+            shadowSizeField = Render.class.getDeclaredField("shadowSize");
+            shadowSizeField.setAccessible(true);
+            return;
+        } catch (NoSuchFieldException ignored) {
+            // Try obfuscated name below.
+        }
+
+        try {
+            shadowSizeField = Render.class.getDeclaredField("field_76989_e");
+            shadowSizeField.setAccessible(true);
+        } catch (NoSuchFieldException ignored) {
+            shadowSizeField = null;
+        }
+    }
+
+    private static double interpolate(double previous, double current, float partialTicks) {
+        return previous + (current - previous) * partialTicks;
+    }
+
+    private static class XrayRenderEntry {
+        private final ResourceLocation entityId;
+        private final EntityLivingBase entity;
+        private final RenderLivingBase renderer;
+        private final double x;
+        private final double y;
+        private final double z;
+        private final float yaw;
+        private final float partialTicks;
+
+        private XrayRenderEntry(ResourceLocation entityId, EntityLivingBase entity, RenderLivingBase renderer,
+                                double x, double y, double z, float yaw, float partialTicks) {
+            this.entityId = entityId;
+            this.entity = entity;
+            this.renderer = renderer;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.yaw = yaw;
+            this.partialTicks = partialTicks;
+        }
+    }
+}

--- a/src/main/java/com/supermobtracker/config/ModConfig.java
+++ b/src/main/java/com/supermobtracker/config/ModConfig.java
@@ -26,6 +26,7 @@ public class ModConfig {
 
     public static boolean clientEnableTracking = true; // can disable tracking entirely
     public static double clientDetectionRange = 64.0; // range for spawn event consideration client side
+    public static boolean clientUseModelXRay = true; // render tracked entities's models instead of using glow outlines
     public static boolean clientI18nNames = true; // localize names in UI/HUD
     public static int clientSpawnCheckRetries = 100; // retry count for random spawn checks
     public static List<String> clientTrackedEntityIds = new ArrayList<>();
@@ -49,6 +50,7 @@ public class ModConfig {
 
     private static final String enableTrackingDesc = I18n.translateToLocal("config.supermobtracker.client.enableTracking.desc");
     private static final String detectionRangeDesc = I18n.translateToLocal("config.supermobtracker.client.detectionRange.desc");
+    private static final String useModelXRayDesc = I18n.translateToLocal("config.supermobtracker.client.useModelXRay.desc");
     private static final String i18nNamesDesc = I18n.translateToLocal("config.supermobtracker.client.i18nNames.desc");
     private static final String spawnCheckRetriesDesc = I18n.translateToLocal("config.supermobtracker.client.spawnCheckRetries.desc");
     private static final String trackedEntityIdsDesc = I18n.translateToLocal("config.supermobtracker.client.trackedEntityIds.desc");
@@ -109,6 +111,10 @@ public class ModConfig {
         prop = config.get("client", "detectionRange", (float) clientDetectionRange, detectionRangeDesc, 8f, 256f);
         prop.setLanguageKey("config.supermobtracker.client.detectionRange");
         clientDetectionRange = prop.getDouble();
+
+        prop = config.get("client", "useModelXRay", clientUseModelXRay, useModelXRayDesc);
+        prop.setLanguageKey("config.supermobtracker.client.useModelXRay");
+        clientUseModelXRay = prop.getBoolean();
 
         prop = config.get("client", "spawnCheckRetries", clientSpawnCheckRetries, spawnCheckRetriesDesc, 1, 1000);
         prop.setLanguageKey("config.supermobtracker.client.spawnCheckRetries");
@@ -393,6 +399,20 @@ public class ModConfig {
 
     public static boolean isClientHudEnabled() {
         return clientHudEnabled;
+    }
+
+    public static boolean isClientUseModelXRay() {
+        return clientUseModelXRay;
+    }
+
+    public static void setClientUseModelXRay(boolean value) {
+        if (clientUseModelXRay == value) return;
+
+        clientUseModelXRay = value;
+        if (config != null) {
+            config.get("client", "useModelXRay", true).set(value);
+            config.save();
+        }
     }
 
     public static List<String> getClientUnstableSimulationEntities() {

--- a/src/main/resources/assets/supermobtracker/lang/en_us.lang
+++ b/src/main/resources/assets/supermobtracker/lang/en_us.lang
@@ -5,7 +5,8 @@ key.categories.supermobtracker=Super Mob Tracker
 
 # Config descriptions
 config.supermobtracker.client.enableTracking.desc=Enable tracking of mobs (requires Minecraft restart).
-config.supermobtracker.client.detectionRange.desc=Range in blocks to detect tracked mobs for glowing effect.
+config.supermobtracker.client.detectionRange.desc=Range in blocks to detect tracked mobs for the x-ray or glow highlight effect.
+config.supermobtracker.client.useModelXRay.desc=Render tracked mobs through walls with their normal model instead of using the vanilla glow outline.
 config.supermobtracker.client.i18nNames.desc=Use localized names in the tracker GUI.
 config.supermobtracker.client.spawnCheckRetries.desc=Maximum retries for spawn condition checks. Higher values handle random spawn conditions better but increase analysis time.
 config.supermobtracker.client.trackedEntityIds.desc=List of entity IDs currently being tracked.
@@ -25,6 +26,7 @@ config.supermobtracker.client.shouldRenderEntities.desc=Entity IDs that crash or
 # Config names (displayed in config GUI)
 config.supermobtracker.client.enableTracking=Enable Tracking
 config.supermobtracker.client.detectionRange=Detection Range
+config.supermobtracker.client.useModelXRay=Use Model X-Ray
 config.supermobtracker.client.i18nNames=Localized Names
 config.supermobtracker.client.spawnCheckRetries=Spawn Check Retries
 config.supermobtracker.client.trackedEntityIds=Tracked Entity IDs


### PR DESCRIPTION
Replace vanilla glowing outlines with a depth based xray entity render pass.
Tracked mobs now keep their normal texture when occluded by world blocks

# Summary
Replace the vanilla glowing outline effect for tracked mobs with a textured xray render pass. This makes tracked mobs visible through world blocks using their normal entity texture instead of the default glowing silhouette.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore/Refactor (no functional changes)
- [ ] Documentation update only

## Related issues
N/A

## What changed
- Added a client-side depth/stencil xray renderer for tracked living entities.
- Registered the new renderer from the client proxy.
- Removed the old per-tick glowing outline application.
- Kept cleanup for legacy temporary glowing flags.

## How to test
Provide steps and any relevant commands.

```cmd
rem From repo root
gradle setupDecompWorkspace
gradle build
```
In-game:
1. Launch the client.
2. Track a mob such as a pig🐖.
3. Place the tracked mob behind solid blocks.
4. Verify the mob renders through blocks with its cool normal texture instead of the vanilla glowing outline.

## Checklist
- [x] I built the project locally with Java 8 using `gradle build`.
- [x] I updated documentation (README/DEVELOPMENT.md) as needed.
- [x] I followed the existing code style.
- [x] I did not include secrets or private data.
- [x] If touching `mcmod.info`, it remains valid and accurate.
- [x] I searched for existing PRs/issues that cover this change.

## Additional context
<img width="2471" height="1116" alt="image" src="https://github.com/user-attachments/assets/988df43b-14e4-41ed-963e-2baa52466a91" />
